### PR TITLE
Pin `docker:dind` image version to 24.0.7

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -17,5 +17,5 @@ else
         -v docker-certs-ca:/certs/ca \
         -v "$BUILDKITE_PLUGIN_DIND_CERTS_VOLUME_NAME":/certs/client \
         -v "$BUILDKITE_PLUGIN_DIND_ADDITIONAL_VOLUME_MOUNT" \
-        docker:dind
+        docker:24.0.7-dind
 fi


### PR DESCRIPTION
Previously the version of `docker:dind` was unpinned. Docker v25.0 was released on Friday 1/19/24 which broke Kuberay CI https://github.com/ray-project/kuberay/issues/1859 because it broke `kind load`.

To verify this we ran `repro-ci.py`, logged into the VM instance, logged into the `docker:dind` container, ran `docker info` and saw that the Docker server version was 25.0.  

This PR pins the version to 24.0.7, the last working version. This should fix KubeRay CI.